### PR TITLE
Add openid-configuration endpoint

### DIFF
--- a/DragaliaBaasServer/Controllers/WellKnownController.cs
+++ b/DragaliaBaasServer/Controllers/WellKnownController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using DragaliaBaasServer.Models.WellKnown;
 using DragaliaBaasServer.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -7,11 +8,11 @@ namespace DragaliaBaasServer.Controllers;
 
 [ApiController]
 [Route(".well-known")]
-public class JwkController : ControllerBase
+public class WellKnownController : ControllerBase
 {
     private readonly IAuthorizationService _authorizationService;
 
-    public JwkController(IAuthorizationService authorizationService)
+    public WellKnownController(IAuthorizationService authorizationService)
     {
         _authorizationService = authorizationService;
     }
@@ -20,5 +21,11 @@ public class JwkController : ControllerBase
     public IActionResult GetJwks()
     {
         return Ok(_authorizationService.GetJwks());
+    }
+
+    [Route("openid-configuration")]
+    public IActionResult GetOpenIdConfiguration()
+    {
+        return Ok(_authorizationService.GetOpenIdConnectConfiguration());
     }
 }

--- a/DragaliaBaasServer/Models/WellKnown/Jwk.cs
+++ b/DragaliaBaasServer/Models/WellKnown/Jwk.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.IdentityModel.Tokens;
 
-namespace DragaliaBaasServer.Models.Jwk;
+namespace DragaliaBaasServer.Models.WellKnown;
 
 public class Jwk
 {

--- a/DragaliaBaasServer/Models/WellKnown/JwkSet.cs
+++ b/DragaliaBaasServer/Models/WellKnown/JwkSet.cs
@@ -1,4 +1,4 @@
-﻿namespace DragaliaBaasServer.Models.Jwk;
+﻿namespace DragaliaBaasServer.Models.WellKnown;
 
 public class JwkSet
 {

--- a/DragaliaBaasServer/Models/WellKnown/OpenIdConnectConfiguration.cs
+++ b/DragaliaBaasServer/Models/WellKnown/OpenIdConnectConfiguration.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace DragaliaBaasServer.Models.WellKnown;
+
+public class OpenIdConnectConfiguration
+{
+    [JsonPropertyName("jwks_uri")]
+    public string JwksUri { get; init; } = string.Empty;
+
+    [JsonPropertyName("id_token_signing_algs_supported")]
+    public IEnumerable<string> IdTokenSigningAlgValuesSupported { get; init; } = Enumerable.Empty<string>();
+
+    [JsonPropertyName("claims_supported")] 
+    public IEnumerable<string> ClaimsSupported { get; init; } = Enumerable.Empty<string>();
+}

--- a/DragaliaBaasServer/Services/AuthorizationService.cs
+++ b/DragaliaBaasServer/Services/AuthorizationService.cs
@@ -5,16 +5,29 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography;
 using System.Text;
 using DragaliaBaasServer.Models.Backend;
-using DragaliaBaasServer.Models.Jwk;
 using DragaliaBaasServer.Models.Web;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.AspNetCore.Components.Authorization;
 using System.Security.Claims;
+using DragaliaBaasServer.Models.WellKnown;
 
 namespace DragaliaBaasServer.Services;
 
 public class AuthorizationService : IAuthorizationService
 {
+    private static readonly OpenIdConnectConfiguration OpenIdConnectConfiguration = new()
+    {
+        JwksUri = Constants.ServerUrl + "/.well-known/jwks.json",
+        ClaimsSupported = new[]
+        {
+            "sub", "iss", "exp", "aud", "sav:a", "sav:ts", "p:id"
+        },
+        IdTokenSigningAlgValuesSupported = new[]
+        {
+            "S256"
+        },
+    };
+        
     private readonly ILogger _logger;
 
     private readonly string _jwtIssuer;
@@ -212,5 +225,10 @@ public class AuthorizationService : IAuthorizationService
 
         principal.AddIdentity(identity);
         return Task.FromResult(new AuthenticationState(principal));
+    }
+
+    public OpenIdConnectConfiguration GetOpenIdConnectConfiguration()
+    {
+        return OpenIdConnectConfiguration;
     }
 }

--- a/DragaliaBaasServer/Services/IAuthorizationService.cs
+++ b/DragaliaBaasServer/Services/IAuthorizationService.cs
@@ -2,8 +2,8 @@
 using DragaliaBaasServer.Models;
 using DragaliaBaasServer.Models.Backend;
 using DragaliaBaasServer.Models.Core;
-using DragaliaBaasServer.Models.Jwk;
 using DragaliaBaasServer.Models.Web;
+using DragaliaBaasServer.Models.WellKnown;
 using Microsoft.AspNetCore.Components.Authorization;
 
 namespace DragaliaBaasServer.Services;
@@ -18,4 +18,5 @@ public interface IAuthorizationService
     public string GenerateRedirectUri(string webUserId, string redirectUriPrefix, string code, string state);
     public bool TryRedeemSessionTokenCode(string stcJwt, string stcCode, [NotNullWhen(true)] out string? webUserId);
     public Task<AuthenticationState> BuildAuthenticationState(WebUserAccount webAccount);
+    public OpenIdConnectConfiguration GetOpenIdConnectConfiguration();
 }


### PR DESCRIPTION
Adds a /.well-known/openid-configuration endpoint that can be used by clients to easily implement JWT authentication of BaaS tokens, for example using AddJwtBearer in C#.