### PR TITLE
Enable SplitQuery globally

### DIFF
--- a/DragaliaBaasServer/Database/DatabaseConfig.cs
+++ b/DragaliaBaasServer/Database/DatabaseConfig.cs
@@ -12,7 +12,10 @@ public static class DatabaseConfig
         services
             .AddDbContext<BaasDbContext>(options =>
             {
-                options.UseNpgsql(BuildConnectionString());
+                options.UseNpgsql(
+                    BuildConnectionString(),
+                    x => x.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
+                );
             })
             .AddScoped<IAccountRepository, DbAccountRepository>();
 


### PR DESCRIPTION
Auto-include of VCM info from #2 is triggering Cartesian explosion warnings.